### PR TITLE
Dev 2.0 router case sensitive

### DIFF
--- a/core/templates/router.tmpl
+++ b/core/templates/router.tmpl
@@ -8,9 +8,7 @@ import _<%- route.hash %> from '@/<%- route.component %>';
     <% } %>
 <% }); %>
 
-let routes = [
-    <%= routesContent %>
-];
+let routes = <%= routesContent %>;
 
 Vue.use(Router);
 

--- a/test/fixtures/pages/index/_other.vue
+++ b/test/fixtures/pages/index/_other.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <h2 class="gray--text">LAVAS</h2>
+        <span>{{webpackDefineTestVar}}</span>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'index',
+    metaInfo: {
+        title: 'Home',
+        meta: [
+            {name: 'keywords', content: 'lavas PWA'}
+        ]
+    },
+    async asyncData({store, route}) {},
+    data() {
+        return {
+            webpackDefineTestVar: DEFINE_TEST_VAR
+        }
+    }
+};
+</script>
+
+<style lang="stylus" scoped>
+h2
+    margin-top 50%
+    font-size 46px
+    font-weight 500
+</style>

--- a/test/fixtures/pages/index/index/Index.vue
+++ b/test/fixtures/pages/index/index/Index.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <h2 class="gray--text">LAVAS</h2>
+        <span>{{webpackDefineTestVar}}</span>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'index',
+    metaInfo: {
+        title: 'Home',
+        meta: [
+            {name: 'keywords', content: 'lavas PWA'}
+        ]
+    },
+    async asyncData({store, route}) {},
+    data() {
+        return {
+            webpackDefineTestVar: DEFINE_TEST_VAR
+        }
+    }
+};
+</script>
+
+<style lang="stylus" scoped>
+h2
+    margin-top 50%
+    font-size 46px
+    font-weight 500
+</style>

--- a/test/fixtures/pages/index/normal.vue
+++ b/test/fixtures/pages/index/normal.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <h2 class="gray--text">LAVAS</h2>
+        <span>{{webpackDefineTestVar}}</span>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'index',
+    metaInfo: {
+        title: 'Home',
+        meta: [
+            {name: 'keywords', content: 'lavas PWA'}
+        ]
+    },
+    async asyncData({store, route}) {},
+    data() {
+        return {
+            webpackDefineTestVar: DEFINE_TEST_VAR
+        }
+    }
+};
+</script>
+
+<style lang="stylus" scoped>
+h2
+    margin-top 50%
+    font-size 46px
+    font-weight 500
+</style>

--- a/test/fixtures/pages/test/Index.vue
+++ b/test/fixtures/pages/test/Index.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <h2 class="gray--text">LAVAS</h2>
+        <span>{{webpackDefineTestVar}}</span>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'testIndex',
+    metaInfo: {
+        title: 'Home',
+        meta: [
+            {name: 'keywords', content: 'lavas PWA'}
+        ]
+    },
+    async asyncData({store, route}) {},
+    data() {
+        return {
+            webpackDefineTestVar: DEFINE_TEST_VAR
+        }
+    }
+};
+</script>
+
+<style lang="stylus" scoped>
+h2
+    margin-top 50%
+    font-size 46px
+    font-weight 500
+</style>

--- a/test/fixtures/pages/test/_id.vue
+++ b/test/fixtures/pages/test/_id.vue
@@ -1,0 +1,23 @@
+<template>
+    <div>
+        Detail Page
+        <router-view></router-view>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'test',
+    metaInfo: {
+        title: 'Detail Page',
+        meta: [
+            {name: 'keywords', content: 'lavas PWA'}
+        ]
+    },
+    async asyncData({store, route}) {}
+};
+</script>
+
+<style lang="stylus" scoped>
+</style>

--- a/test/unit/route-manager.test.js
+++ b/test/unit/route-manager.test.js
@@ -27,10 +27,10 @@ test.serial('it should generate main/router.js in .lavas directory', async t => 
 
     let content = await readFile(join(__dirname, '../fixtures/.lavas/main/router.js'), 'utf8');
 
-    t.true(content.indexOf('path: \':id\'') > -1
-        && content.indexOf('name: \'detailId\'') > -1
-        && content.indexOf('path: \'/\'') > -1
-        && content.indexOf('name: \'index\'') > -1);
+    t.true(content.indexOf('"path": ":id"') > -1
+        && content.indexOf('"name": "detailId"') > -1
+        && content.indexOf('"path": "/"') > -1
+        && content.indexOf('"name": "index"') > -1);
 });
 
 /**
@@ -68,10 +68,14 @@ test.serial('it should modify route objects based on router config', async t => 
     t.true(content.indexOf('() => import(/* webpackChunkName: \"my-chunk\" */\'@/pages/detail/_id.vue\');') > -1);
 
     // rewrite route path
-    t.true(content.indexOf('path: \'/rewrite/detail\'') > -1);
+    t.true(content.indexOf('"path": "/rewrite/detail"') > -1);
 
     // support route meta
-    t.true(content.indexOf('meta: {"keepAlive":true}') > -1);
+    t.true(content.indexOf(
+        `"meta": {
+            "keepAlive": true
+        }`
+    ) > -1);
 });
 
 // function emptyRegExp(routes) {

--- a/test/unit/utils/router.test.js
+++ b/test/unit/utils/router.test.js
@@ -11,7 +11,7 @@ import test from 'ava';
 test('it should generate routes according to the structure of directory', async t => {
     let routes = await generateRoutes(join(__dirname, '../../fixtures/pages'));
 
-    t.true(routes.length === 4);
+    t.true(routes.length === 6);
 
     // dynamic param :id
     t.deepEqual(routes[0], {
@@ -46,16 +46,28 @@ test('it should generate routes according to the structure of directory', async 
         name: 'parent',
         children: [
             {
-                component: "pages/parent/Child1.vue",
-                name: "parentChild1",
-                path: "child1",
-            },
-            {
                 component: "pages/parent/Child2.vue",
                 name: "parentChild2",
                 path: "child2",
+            },
+            {
+                component: "pages/parent/Child1.vue",
+                name: "parentChild1",
+                path: "child1",
             }
         ]
+    });
+
+    t.deepEqual(routes[4], {
+        component: "pages/test/Index.vue",
+        name: "testIndex",
+        path: "/test",
+    });
+
+    t.deepEqual(routes[5], {
+        component: "pages/test/_id.vue",
+        name: "testId",
+        path: "/test/:id",
     });
 });
 

--- a/test/unit/utils/router.test.js
+++ b/test/unit/utils/router.test.js
@@ -36,7 +36,23 @@ test('it should generate routes according to the structure of directory', async 
     t.deepEqual(routes[2], {
         path: '/',
         component: 'pages/Index.vue',
-        name: 'index'
+        children: [
+            {
+                component: "pages/index/_other.vue",
+                name: "indexOther",
+                path: ":other"
+            },
+            {
+                component: "pages/index/index/Index.vue",
+                name: "index",
+                path: ""
+            },
+            {
+                component: "pages/index/normal.vue",
+                name: "indexNormal",
+                path: "normal"
+            },
+        ]
     });
 
     // nested routes
@@ -46,25 +62,25 @@ test('it should generate routes according to the structure of directory', async 
         name: 'parent',
         children: [
             {
-                component: "pages/parent/Child2.vue",
-                name: "parentChild2",
-                path: "child2",
-            },
-            {
                 component: "pages/parent/Child1.vue",
                 name: "parentChild1",
                 path: "child1",
+            },
+            {
+                component: "pages/parent/Child2.vue",
+                name: "parentChild2",
+                path: "child2",
             }
         ]
     });
 
-    t.deepEqual(routes[4], {
+    t.deepEqual(routes[5], {
         component: "pages/test/Index.vue",
-        name: "testIndex",
+        name: "test",
         path: "/test",
     });
 
-    t.deepEqual(routes[5], {
+    t.deepEqual(routes[4], {
         component: "pages/test/_id.vue",
         name: "testId",
         path: "/test/:id",


### PR DESCRIPTION
1）修复了原先的 route generator 在 linux 环境下存在大小写敏感的 bug，诸如 pages/**/index.vue 这样的以小写字母为开头的文件，系统默认生成的路由找的却是 pages/**/Index.vue ；
2）修复嵌套路由的bug：嵌套路由情况下，如果存在默认子路由，应去掉父路由的 name 属性；
3）新增 pathRule 配置项 （config/router.js），可配置的值有：'raw'、'camelCase'、'lowerCase'、’kebabCase‘，默认为 kebabCase。通过该配置项可以指定通过文件名生成的路径风格，比如 pages/AaBb.vue 对应生成的路由为 /aa-bb (kebabCase) ；