### PR TITLE
feat: expose render function

### DIFF
--- a/packages/lavas-core-vue/core/index.js
+++ b/packages/lavas-core-vue/core/index.js
@@ -57,7 +57,7 @@ export default class LavasCore extends EventEmitter {
             .bind(this.middlewareComposer);
 
         // expose render function
-        // this.render = this.renderer.render.bind(this.renderer);
+        this.render = this.renderer.render.bind(this.renderer);
 
         if (!this.isProd) {
             // register rebuild listener
@@ -85,15 +85,12 @@ export default class LavasCore extends EventEmitter {
         let spinner = ora();
         spinner.start();
 
-        if (!this.isProd) {
-            this.middlewareComposer.setup();
-        }
         try {
             await this.builder.build();
             spinner.succeed(`[Lavas] ${this.env} build completed.`);
         }
         catch (e) {
-            console.log(e);
+            console.error(e);
             spinner.fail(`[Lavas] ${this.env} build failed.`)
         }
 
@@ -104,8 +101,6 @@ export default class LavasCore extends EventEmitter {
      *
      */
     async runAfterBuild() {
-        this.middlewareComposer.setup();
-        this.renderer = new Renderer(this);
         // create with bundle & manifest
         await this.renderer.createWithBundle();
     }

--- a/packages/lavas-core-vue/core/middleware-composer.js
+++ b/packages/lavas-core-vue/core/middleware-composer.js
@@ -20,6 +20,19 @@ import koaErrorFactory from './middlewares/koa-error';
 import expressErrorFactory from './middlewares/express-error';
 import staticFactory from './middlewares/static';
 
+// enum of internal middlewares
+const INTERNAL_MIDDLEWARE = {
+    TRAILING_SLASH: 'trailing-slash',
+    STATIC: 'static',
+    SERVICE_WORKER: 'service-worker',
+    FAVICON: 'favicon',
+    COMPRESSION: 'compression',
+    SSR: 'ssr',
+    ERROR: 'error'
+};
+
+const ALL_MIDDLEWARES = Object.keys(INTERNAL_MIDDLEWARE).map(key => INTERNAL_MIDDLEWARE[key]);
+
 export default class MiddlewareComposer {
     constructor(core) {
         this.core = core;
@@ -29,11 +42,16 @@ export default class MiddlewareComposer {
         this.internalMiddlewares = [];
     }
 
-    add(middleware) {
+    add(middleware, head = false) {
         if (typeof middleware !== 'function') {
             throw new Error('Middleware must be a function.');
         }
-        this.internalMiddlewares.push(middleware);
+        if (head) {
+            this.internalMiddlewares.unshift(middleware);
+        }
+        else {
+            this.internalMiddlewares.push(middleware);
+        }
     }
 
     reset(config) {
@@ -62,7 +80,11 @@ export default class MiddlewareComposer {
      *
      * @return {Function} koaMiddleware
      */
-    koa() {
+    koa(selectedMiddlewares = ALL_MIDDLEWARES) {
+        if (!Array.isArray(selectedMiddlewares)) {
+            selectedMiddlewares = [selectedMiddlewares];
+        }
+
         const composeKoa = require('koa-compose');
         const c2k = require('koa-connect');
         const mount = require('koa-mount');
@@ -72,26 +94,42 @@ export default class MiddlewareComposer {
         let {router: {base}, build: {ssr, publicPath}, serviceWorker, errorHandler} = this.config;
         base = removeTrailingSlash(base || '/');
 
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.COMPRESSION)) {
+            // gzip compression
+            this.add(compression());
+        }
+
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.FAVICON)) {
+            // serve favicon
+            let faviconPath = posix.join(this.cwd, ASSETS_DIRNAME_IN_DIST, 'img/icons/favicon.ico');
+            this.add(favicon(faviconPath));
+        }
+
         // transform express/connect style middleware to koa style
-        let middlewares = [
-            koaErrorFactory(errorHandler.errorPath),
-            async (ctx, next) => {
-                // koa defaults to 404 when it sees that status is unset
-                ctx.status = 200;
-                await next();
-            },
-            ...this.internalMiddlewares.map(c2k)
-        ];
+        this.internalMiddlewares = this.internalMiddlewares.map(c2k);
+
+        // koa defaults to 404 when it sees that status is unset
+        this.add(async (ctx, next) => {
+            ctx.status = 200;
+            await next();
+        }, true);
+
+        // handle errors
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.ERROR)) {
+            this.add(koaErrorFactory(errorHandler.errorPath), true);
+        }
 
         // Redirect without trailing slash.
-        middlewares.push(async (ctx, next) => {
-            if (base === ctx.path) {
-                ctx.redirect(`${ctx.path}/${ctx.search}`);
-            }
-            else {
-                await next();
-            }
-        });
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.TRAILING_SLASH)) {
+            this.add(async (ctx, next) => {
+                if (base === ctx.path) {
+                    ctx.redirect(`${ctx.path}/${ctx.search}`);
+                }
+                else {
+                    await next();
+                }
+            });
+        }
 
         if (ssr) {
             /**
@@ -100,19 +138,23 @@ export default class MiddlewareComposer {
              * Don't need this middleware when CDN being used to serve static files.
              */
             if (this.isProd && !isFromCDN(publicPath)) {
-                // serve /static
-                middlewares.push(mount(
-                    posix.join(publicPath, ASSETS_DIRNAME_IN_DIST),
-                    koaStatic(join(this.cwd, ASSETS_DIRNAME_IN_DIST))
-                ));
+
+                if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.STATIC)) {
+                    // serve /static
+                    this.add(mount(
+                        posix.join(publicPath, ASSETS_DIRNAME_IN_DIST),
+                        koaStatic(join(this.cwd, ASSETS_DIRNAME_IN_DIST))
+                    ));
+                }
 
                 // serve sw-register.js & sw.js
-                if (serviceWorker && serviceWorker.swDest) {
+                if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.SERVICE_WORKER)
+                    && serviceWorker && serviceWorker.swDest) {
                     let swFiles = [
                         basename(serviceWorker.swDest),
                         'sw-register.js'
                     ].map(f => posix.join(publicPath, f));
-                    middlewares.push(async (ctx, next) => {
+                    this.add(async (ctx, next) => {
                         let done = false;
                         if (swFiles.includes(ctx.path)) {
                             // Don't cache service-worker.js & sw-register.js.
@@ -127,10 +169,13 @@ export default class MiddlewareComposer {
                     });
                 }
             }
-            middlewares.push(c2k(ssrFactory(this.core)));
+
+            if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.SSR)) {
+                this.add(c2k(ssrFactory(this.core)));
+            }
         }
 
-        return composeKoa(middlewares);
+        return composeKoa(this.internalMiddlewares);
     }
 
     /**
@@ -138,28 +183,43 @@ export default class MiddlewareComposer {
      *
      * @return {Function} expressMiddleware
      */
-    express() {
+    express(selectedMiddlewares = ALL_MIDDLEWARES) {
+        if (!Array.isArray(selectedMiddlewares)) {
+            selectedMiddlewares = [selectedMiddlewares];
+        }
+
         let expressRouter = Router;
-        let {router: {base}, build: {ssr, publicPath}, serviceWorker, errorHandler} = this.config;
+        let {router: {base}, build: {ssr, publicPath, compress}, serviceWorker, errorHandler} = this.config;
         base = removeTrailingSlash(base || '/');
 
-        let middlewares = Array.from(this.internalMiddlewares);
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.COMPRESSION)) {
+            // gzip compression
+            this.add(compression());
+        }
 
-        // Redirect without trailing slash.
-        let rootRouter = expressRouter();
-        rootRouter.get(
-            base,
-            (req, res, next) => {
-                let url = parse(req.url);
-                if (!url.pathname.endsWith('/')) {
-                    res.redirect(301, url.pathname + '/' + (url.search || ''));
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.FAVICON)) {
+            // serve favicon
+            let faviconPath = posix.join(this.cwd, ASSETS_DIRNAME_IN_DIST, 'img/icons/favicon.ico');
+            this.add(favicon(faviconPath));
+        }
+
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.TRAILING_SLASH)) {
+            // Redirect without trailing slash.
+            let rootRouter = expressRouter();
+            rootRouter.get(
+                base,
+                (req, res, next) => {
+                    let url = parse(req.url);
+                    if (!url.pathname.endsWith('/')) {
+                        res.redirect(301, url.pathname + '/' + (url.search || ''));
+                    }
+                    else {
+                        next();
+                    }
                 }
-                else {
-                    next();
-                }
-            }
-        );
-        middlewares.unshift(rootRouter);
+            );
+            this.add(rootRouter, true);
+        }
 
         if (ssr) {
             /**
@@ -169,40 +229,49 @@ export default class MiddlewareComposer {
              */
             if (this.isProd && !isFromCDN(publicPath)) {
                 // Serve /static.
-                let staticRouter = expressRouter();
-                staticRouter.get(
-                    posix.join(publicPath, ASSETS_DIRNAME_IN_DIST, '*'),
-                    staticFactory(publicPath)
-                );
-                middlewares.push(staticRouter);
-                // Don't use etag or cache-control.
-                middlewares.push(serveStatic(this.cwd, {
-                    cacheControl: false,
-                    etag: false
-                }));
-
-                // Serve sw-register.js & sw.js.
-                if (serviceWorker && serviceWorker.swDest) {
-                    let swFiles = [
-                        basename(serviceWorker.swDest),
-                        'sw-register.js'
-                    ].map(f => posix.join(publicPath, f));
-                    let swRouter = expressRouter();
-                    swRouter.get(swFiles, staticFactory(publicPath));
-                    middlewares.push(swRouter);
-                    // Use cache-control but not etag.
-                    middlewares.push(serveStatic(this.cwd, {
+                if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.STATIC)) {
+                    let staticRouter = expressRouter();
+                    staticRouter.get(
+                        posix.join(publicPath, ASSETS_DIRNAME_IN_DIST, '*'),
+                        staticFactory(publicPath)
+                    );
+                    this.add(staticRouter);
+                    // Don't use etag or cache-control.
+                    this.add(serveStatic(this.cwd, {
+                        cacheControl: false,
                         etag: false
                     }));
                 }
+
+                // Serve sw-register.js & sw.js.
+                if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.SERVICE_WORKER)) {
+                    if (serviceWorker && serviceWorker.swDest) {
+                        let swFiles = [
+                            basename(serviceWorker.swDest),
+                            'sw-register.js'
+                        ].map(f => posix.join(publicPath, f));
+                        let swRouter = expressRouter();
+                        swRouter.get(swFiles, staticFactory(publicPath));
+                        this.add(swRouter);
+                        // Use cache-control but not etag.
+                        this.add(serveStatic(this.cwd, {
+                            etag: false
+                        }));
+                    }
+                }
             }
 
-            middlewares.push(ssrFactory(this.core));
+            // SSR middleware.
+            if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.SSR)) {
+                this.add(ssrFactory(this.core));
+            }
         }
 
         // Handle errors.
-        middlewares.push(expressErrorFactory(errorHandler.errorPath));
+        if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.ERROR)) {
+            this.add(expressErrorFactory(errorHandler.errorPath));
+        }
 
-        return compose(middlewares);
+        return compose(this.internalMiddlewares);
     }
 }

--- a/packages/lavas-core-vue/core/middlewares/ssr.js
+++ b/packages/lavas-core-vue/core/middlewares/ssr.js
@@ -21,25 +21,20 @@ export default function (core) {
         }
 
         let url = req.url;
+        let errorHandler = err => next(err);
 
         console.log(`[Lavas] route middleware: ssr ${url}`);
-        let matchedRenderer = await renderer.getRenderer();
-        let errorHandler = err => next(err);
-        let ctx = {
-            title: 'Lavas', // default title
+
+        let {err, html} = await renderer.render({
             url,
-            config: builder && builder.config || config, // mount config to ctx which will be used when rendering template
             req,
             res,
             error: errorHandler
-        };
-
-        // render to string
-        matchedRenderer.renderToString(ctx, (err, html) => {
-            if (err) {
-                return next(err);
-            }
-            res.end(html);
         });
+
+        if (err) {
+            return next(err);
+        }
+        res.end(html);
     };
 }

--- a/packages/lavas-core-vue/test/fixtures/core/Skeleton.vue
+++ b/packages/lavas-core-vue/test/fixtures/core/Skeleton.vue
@@ -17,8 +17,6 @@ export default {
 
 <style lang="stylus" scoped>
 
-@import '~normalize.css';
-
 .skeleton-wrapper
     position fixed
     top 0

--- a/packages/lavas-core-vue/test/fixtures/lavas.config.js
+++ b/packages/lavas-core-vue/test/fixtures/lavas.config.js
@@ -9,13 +9,13 @@ const path = require('path');
 const BUILD_PATH = path.resolve(__dirname, 'dist');
 
 module.exports = {
-    ssr: true,
     middleware: {
         server: ['server-only'],
         client: ['client-only'],
         all: ['both']
     },
     build: {
+        ssr: true,
         path: BUILD_PATH,
         defines: {
             base: {
@@ -34,7 +34,7 @@ module.exports = {
     serviceWorker: {
         swSrc: path.join(__dirname, 'core/service-worker.js'),
         swDest: path.join(BUILD_PATH, 'service-worker.js'),
-        globDirectory: path.basename(BUILD_PATH),
+        globDirectory: BUILD_PATH,
         globPatterns: [
             '**/*.{html,js,css,eot,svg,ttf,woff}'
         ],

--- a/packages/lavas-core-vue/test/integration/lavas-middlewares.js
+++ b/packages/lavas-core-vue/test/integration/lavas-middlewares.js
@@ -1,0 +1,89 @@
+/**
+ * @file Test case for `express/koaMiddleware()` and `render()` functions.
+ * @author panyuqi@baidu.com (panyuqi)
+ */
+
+import {join} from 'path';
+import test from 'ava';
+import LavasCore from '../../dist';
+
+import {syncConfig, isKoaSupport, request, createApp} from '../utils';
+
+let app;
+let server;
+let port = process.env.PORT || 3000;
+let core;
+
+test.beforeEach('init lavas-core & server', async t => {
+    core = new LavasCore(join(__dirname, '../fixtures'));
+    app = createApp();
+});
+
+test.afterEach('clean', t => {
+    server && server.close();
+});
+
+async function runCommonTestCases(t) {
+    // only use static middleware
+    let selectedInternalMidds = ['static', 'favicon'];
+    let addtionalContent = '<div>addtional content</div>';
+
+    // set middlewares & start a server
+    if (isKoaSupport) {
+        app.use(core.koaMiddleware(selectedInternalMidds));
+
+        // use custom SSR middleware
+        app.use(async (ctx, next) => {
+            let {err, html} = await core.render({
+                url: ctx.path
+            });
+            ctx.body = html.replace('</html>', `${addtionalContent}</html>`);
+        });
+    }
+    else {
+        app.use(core.expressMiddleware(selectedInternalMidds));
+
+        // use custom SSR middleware
+        app.use((req, res, next) => {
+            core.render({
+                url: req.url
+            }).then(result => {
+                if (result.err) {
+                    return next(result.err);
+                }
+                res.end(result.html.replace('</html>', `${addtionalContent}</html>`));
+            });
+        });
+    }
+
+    server = app.listen(port);
+
+    // server side render index
+    let ssrContent = '<div id="app" data-server-rendered="true">';
+    let res = await request(app)
+        .get('/');
+    t.is(200, res.status);
+    t.true(res.text.indexOf(ssrContent) > -1);
+    t.true(res.text.indexOf(addtionalContent) > -1);
+}
+
+test.serial('it should run in development mode correctly', async t => {
+    // init, build and start a dev server
+    await core.init('development', true);
+    await core.build();
+
+    await runCommonTestCases(t);
+});
+
+test.serial('it should run in production mode correctly', async t => {
+    // build in production mode
+    await core.init('production', true);
+    await core.build();
+
+    // start server in production mode
+    core = new LavasCore(join(__dirname, '../fixtures/dist'));
+    await core.init('production');
+    await core.runAfterBuild();
+
+    await runCommonTestCases(t);
+});


### PR DESCRIPTION
* Lavas internal middlewares such as `static`, `service-worker`, `ssr`, `error` and `favicon` can be toggled by calling `express/koaMiddleware()`
* Provide `render()` function so that custom SSR middleware can be used in **SSR** mode.
* Some test cases should be provided later.