### PR TITLE
恢复extend context.type === 'base' 避免和老代码发生冲突

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 =======
 
+## Lavas-core-vue [1.1.4] - 2018-3-9
+
+### Changed
+
+- [Fix] Resume supporting `context.type === 'base'` in `extend` function in `lavas.config.js`
+
 ## Lavas-core-vue [1.1.3] - 2018-3-8
 
 ### Changed

--- a/packages/lavas-core-vue/core/webpack.js
+++ b/packages/lavas-core-vue/core/webpack.js
@@ -334,6 +334,10 @@ export default class WebpackConfig {
         // call extend function if provided
         if (typeof extend === 'function') {
             extend.call(this, webpackConfigObject, {
+                type: 'base',
+                env: this.env
+            });
+            extend.call(this, webpackConfigObject, {
                 type: 'client',
                 env: this.env
             });
@@ -426,6 +430,10 @@ export default class WebpackConfig {
 
         // call extend function if provided
         if (typeof extend === 'function') {
+            extend.call(this, webpackConfigObject, {
+                type: 'base',
+                env: this.env
+            });
             extend.call(this, webpackConfigObject, {
                 type: 'server',
                 env: this.env

--- a/packages/lavas-core-vue/package.json
+++ b/packages/lavas-core-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavas-core-vue",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Lavas core implemented by Vue",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
在我们改用 webpack-chain 的同时，对 `lavas.config.js` 中的 `extend` 进行了修改，取消了 `context.type === 'base'`。
但在多处文档（如 [svg-loader codelab](https://lavas.baidu.com/codelab/svg-loader/03svg-loader)）包括开发者本地的代码还保留着这个判断，这样会导致失效。因此还是要把 `'base'` 恢复回来。

以后类似的改动一定要多多考虑开发者手里的代码，修改文档事小，开发者的代码因为 core 的更新跑不起来就不太合理了。