### PR TITLE
Fix build

### DIFF
--- a/packages/lavas-cli/package.json
+++ b/packages/lavas-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavas",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Lavas solution cli tool",
   "main": "dist/index.js",
   "files": [

--- a/packages/lavas-cli/src/commander/build/build.js
+++ b/packages/lavas-cli/src/commander/build/build.js
@@ -40,7 +40,7 @@ module.exports = async function (config) {
     let rootDir = utils.getLavasProjectRoot();
     let buildScriptPath = path.resolve(rootDir, '.lavas/build.js');
 
-    // 存在.lavas/build.js 直接调用，避免引用全局 lavas-core-vue
+    // 不存在.lavas/build.js 时复制 build.js，避免调用全局 lavas-core-vue
     if (!await fs.pathExists(buildScriptPath)) {
         await fs.copy(path.resolve(__dirname, '../../templates/build.js'), buildScriptPath);
     }
@@ -52,16 +52,4 @@ module.exports = async function (config) {
     }
 
     fork(buildScriptPath, options);
-
-    // 通过 package.json 中的配置将 lavas-core 从命令行解耦
-    // 要求所有的 core 都提供相同的 API
-    // let lavasConf = require(path.resolve(rootDir, 'package.json')).lavas || {};
-
-    // let LavasCore = require(lavasConf.core || 'lavas-core-vue');
-    // let core = new LavasCore(rootDir);
-
-    // let configPath = await getConfigPath(config);
-
-    // await core.init(process.env.NODE_ENV || 'production', true, {config: configPath});
-    // await core.build();
 };

--- a/packages/lavas-cli/src/commander/build/build.js
+++ b/packages/lavas-cli/src/commander/build/build.js
@@ -41,26 +41,27 @@ module.exports = async function (config) {
     let buildScriptPath = path.resolve(rootDir, '.lavas/build.js');
 
     // 存在.lavas/build.js 直接调用，避免引用全局 lavas-core-vue
-    if (await fs.pathExists(buildScriptPath)) {
-        let options = [];
-        let configPath = await getConfigPath(config);
-        if (configPath) {
-            options.push(configPath);
-        }
-
-        fork(buildScriptPath, options);
-        return;
+    if (!await fs.pathExists(buildScriptPath)) {
+        await fs.copy(path.resolve(__dirname, '../../templates/build.js'), buildScriptPath);
     }
+
+    let options = [];
+    let configPath = await getConfigPath(config);
+    if (configPath) {
+        options.push(configPath);
+    }
+
+    fork(buildScriptPath, options);
 
     // 通过 package.json 中的配置将 lavas-core 从命令行解耦
     // 要求所有的 core 都提供相同的 API
-    let lavasConf = require(path.resolve(rootDir, 'package.json')).lavas || {};
+    // let lavasConf = require(path.resolve(rootDir, 'package.json')).lavas || {};
 
-    let LavasCore = require(lavasConf.core || 'lavas-core-vue');
-    let core = new LavasCore(rootDir);
+    // let LavasCore = require(lavasConf.core || 'lavas-core-vue');
+    // let core = new LavasCore(rootDir);
 
-    let configPath = await getConfigPath(config);
+    // let configPath = await getConfigPath(config);
 
-    await core.init(process.env.NODE_ENV || 'production', true, {config: configPath});
-    await core.build();
+    // await core.init(process.env.NODE_ENV || 'production', true, {config: configPath});
+    // await core.build();
 };

--- a/packages/lavas-cli/src/commander/build/build.js
+++ b/packages/lavas-cli/src/commander/build/build.js
@@ -40,7 +40,7 @@ module.exports = async function (config) {
     let rootDir = utils.getLavasProjectRoot();
     let buildScriptPath = path.resolve(rootDir, '.lavas/build.js');
 
-    // 不存在.lavas/build.js 时复制 build.js，避免调用全局 lavas-core-vue
+    // 不存在.lavas/build.js 时创建 build.js，避免调用全局 lavas-core-vue
     if (!await fs.pathExists(buildScriptPath)) {
         await fs.copy(path.resolve(__dirname, '../../templates/build.js'), buildScriptPath);
     }

--- a/packages/lavas-cli/src/templates/build.js
+++ b/packages/lavas-cli/src/templates/build.js
@@ -1,0 +1,17 @@
+var path = require('path');
+
+var LavasCore = require('lavas-core-vue');
+var core = new LavasCore(path.resolve(__dirname, '../'));
+
+var config;
+
+// fix https://github.com/lavas-project/lavas/issues/50
+if (process.argv.length >= 3 && process.argv[2] !== 'build') {
+    config = process.argv[2];
+}
+
+process.env.NODE_ENV = 'production';
+
+core.init(process.env.NODE_ENV, true, {config}).then(function () {
+    core.build();
+});

--- a/packages/lavas-core-vue/test/unit/utils/path.test.js
+++ b/packages/lavas-core-vue/test/unit/utils/path.test.js
@@ -3,7 +3,7 @@
  * @author panyuqi (pyqiverson@gmail.com)
  */
 
-import {distLavasPath, assetsPath, resolveAliasPath, isFromCDN, removeTrailingSlash} from '../../../core/utils/path';
+import {distLavasPath, assetsPath, resolveAliasPath, isFromCDN, removeTrailingSlash, camelCaseToDash} from '../../../core/utils/path';
 import {sep} from 'path';
 import test from 'ava';
 
@@ -36,8 +36,14 @@ test('it should test whether a path is from CDN', t => {
     t.true(isFromCDN(urlC));
 });
 
-// removeTrailingSlash
+// removeTrailingSlash()
 test('it should remove trailing slash correctly', t => {
     t.is('foo/bar', removeTrailingSlash('foo/bar/'));
     t.is('foo/bar', removeTrailingSlash('foo/bar'));
+});
+
+// camelCaseToDash()
+test('it should transfer from camel case to dash', t => {
+    t.is('camel-case-to-dash', camelCaseToDash('camelCaseToDash'));
+    t.is('already-camel-case', camelCaseToDash('already-camel-case'));
 });


### PR DESCRIPTION
在 `lavas build` 命令中，发现项目中不存在 `.lavas/build.js` 时复制过去，避免开发者必须先运行 `lavas dev` 才能运行 `lavas build`。