### PR TITLE
core: approve await

### DIFF
--- a/packages/lavas-core-vue/core/builder/base-builder.js
+++ b/packages/lavas-core-vue/core/builder/base-builder.js
@@ -4,7 +4,7 @@
  */
 
 import template from 'lodash.template';
-import {readFile, pathExists} from 'fs-extra';
+import {readFile, pathExistsSync} from 'fs-extra';
 import {join, basename, normalize} from 'path';
 
 import HtmlWebpackPlugin from 'html-webpack-plugin';
@@ -118,7 +118,7 @@ export default class BaseBuilder {
 
     async writeMiddleware() {
         const middlewareTemplate = this.templatesPath('middleware.tmpl');
-        let isEmpty = !(await pathExists(join(this.config.globals.rootDir, 'middlewares')));
+        let isEmpty = !(pathExistsSync(join(this.config.globals.rootDir, 'middlewares')));
 
         await this.writeFileToLavasDir(
             'middleware.js',
@@ -130,7 +130,7 @@ export default class BaseBuilder {
 
     async writeStore() {
         const storeTemplate = this.templatesPath('store.tmpl');
-        let isEmpty = !(await pathExists(join(this.config.globals.rootDir, 'store')));
+        let isEmpty = !(pathExistsSync(join(this.config.globals.rootDir, 'store')));
 
         await this.writeFileToLavasDir(
             STORE_FILE,
@@ -173,12 +173,12 @@ export default class BaseBuilder {
 
         // find core/spa.html.tmpl
         templatePath = join(rootDir, `core/${SPA_TEMPLATE_HTML}`);
-        if (!await pathExists(templatePath)) {
+        if (!pathExistsSync(templatePath)) {
             // find core/index.html.tmpl
             templatePath = join(rootDir, `core/${TEMPLATE_HTML}`);
         }
 
-        if (!await pathExists(templatePath)) {
+        if (!pathExistsSync(templatePath)) {
             throw new Error(`${SPA_TEMPLATE_HTML} or ${TEMPLATE_HTML} required`);
         }
 
@@ -320,7 +320,7 @@ export default class BaseBuilder {
                 resolveAliasPath(alias, currentRoute.componentPath)
             ];
             for (let j = 0; j < resolvedPaths.length; j++) {
-                if (await pathExists(resolvedPaths[j])) {
+                if (pathExistsSync(resolvedPaths[j])) {
                     // in Windows, normalize will replace posix.sep`/` with win32.sep`\\`
                     currentRoute.componentPath = normalize(resolvedPaths[j])
                         .replace(/\\/g, '\\\\'); // escape backslash before writing to skeleton template

--- a/packages/lavas-core-vue/core/builder/prod-builder.js
+++ b/packages/lavas-core-vue/core/builder/prod-builder.js
@@ -35,9 +35,11 @@ export default class ProdBuilder extends BaseBuilder {
         Logger.info('build', 'compiling routes completed.', true);
 
         Logger.info('build', 'start writing files to /.lavas...', true);
-        await this.writeRuntimeConfig();
-        await this.writeMiddleware();
-        await this.writeStore();
+        await Promise.all([
+            this.writeRuntimeConfig(),
+            this.writeMiddleware(),
+            this.writeStore()
+        ])
         Logger.info('build', 'writing files to /.lavas completed', true);
 
         // SSR build process


### PR DESCRIPTION
`await`配合thread_pool效率比直接调用`uv__fs_work`低很多，benchmark代码如下：
```js
const fs = require('fs-extra')
const Benchmark = require('benchmark')
const path = require('path')

let suite = new Benchmark.Suite

async function asyncF(){
  await fs.pathExists(path.join(process.cwd(), '../bin'))
}
function F(){
  fs.pathExistsSync(path.join(process.cwd(), '../bin'))
}
suite.add('Async test', function() {
  asyncF()
})
.add('sync test', function() {
  F()
})
.on('cycle', function(event) {
  console.log(String(event.target));
})
.on('complete', function() {
  console.log('Fastest is ' + this.filter('fastest').map('name'));
})
.run({ 'async': true });
```
结果：
![image](https://user-images.githubusercontent.com/5475069/39393728-713124a4-4afb-11e8-8de4-17907193e2c5.png)
同步效率为async+thread_pool四倍+