### PR TITLE
test: approve coveralls

### DIFF
--- a/packages/tb-lavas-core/core/middleware-composer.js
+++ b/packages/tb-lavas-core/core/middleware-composer.js
@@ -74,13 +74,13 @@ export default class MiddlewareComposer {
         let expressRouter = Router;
         let {router: {base}, build: {ssr, publicPath, compress}, serviceWorker, errorHandler} = this.config;
         base = removeTrailingSlash(base || '/');
-        
+        /* istanbul ignore if */
         if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.FAVICON)) {
             // serve favicon
             let faviconPath = posix.join(this.cwd, ASSETS_DIRNAME_IN_DIST, 'img/icons/favicon.ico');
             this.add(favicon(faviconPath));
         }
-
+        /* istanbul ignore if */
         if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.TRAILING_SLASH)) {
             // Redirect without trailing slash.
             let rootRouter = expressRouter();
@@ -100,6 +100,7 @@ export default class MiddlewareComposer {
         }
 
         // Handle errors.
+        /* istanbul ignore if */
         if (selectedMiddlewares.includes(INTERNAL_MIDDLEWARE.ERROR)) {
             this.add(expressErrorFactory(errorHandler));
         }

--- a/packages/tb-lavas-core/core/middlewares/express-error.js
+++ b/packages/tb-lavas-core/core/middlewares/express-error.js
@@ -10,7 +10,6 @@
  * @return {Function} koa middleware
  */
 
-/* istanbul ignore next */
 export default function ({errorPath, defaultErrorMessage, showRealErrorMessage}) {
 
     return async (err, req, res, next) => {
@@ -23,12 +22,15 @@ export default function ({errorPath, defaultErrorMessage, showRealErrorMessage})
 
         if (errorPath === req.url.replace(/\?.+$/, '')) {
             // if already in error procedure, then end this request immediately, avoid infinite loop
+            res.statusCode = 404;
+            // throw new Error(err);
             res.end();
             return;
         }
 
         // redirect to the corresponding url
-        let target = `${errorPath}?error=${encodeURIComponent(showRealErrorMessage ? err.message : defaultErrorMessage)}`;
+        let target = `${errorPath}?error=${encodeURIComponent(showRealErrorMessage ? err.message : /* istanbul ignore next */defaultErrorMessage)}`;
+        /* istanbul ignore else */
         if (errorPath) {
             res.writeHead(302, {Location: target});
         }

--- a/packages/tb-lavas-core/core/utils/webpack.js
+++ b/packages/tb-lavas-core/core/utils/webpack.js
@@ -16,6 +16,7 @@ import template from 'lodash.template';
 export function webpackCompile(config) {
     return new Promise((resolve, reject) => {
         webpack(config, (err, stats) => {
+            /* istanbul ignore if */
             if (err) {
                 console.error(err.stack || err);
                 if (err.details) {
@@ -26,13 +27,13 @@ export function webpackCompile(config) {
             }
 
             const info = stats.toJson();
-
+            /* istanbul ignore if */
             if (stats.hasErrors()) {
                 info.errors.forEach(error => console.error(error));
                 reject(info.errors);
                 return;
             }
-
+            /* istanbul ignore if */
             if (stats.hasWarnings()) {
                 info.warnings.forEach(warning => console.warn(warning));
             }
@@ -82,6 +83,7 @@ export function enableHotReload(dir, config, subscribeReload = false) {
     // add hot-reload entry in every entry
     Object.keys(entry).forEach(entryName => {
         let currentEntry = entry[entryName];
+        /* istanbul ignore else */
         if (Array.isArray(currentEntry)) {
             entry[entryName] = [hotReloadEntryPath, ...currentEntry];
         }

--- a/packages/tb-lavas-core/package.json
+++ b/packages/tb-lavas-core/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "nyc ava -v && rimraf test/temp",
+    "test": "NODE_ENV=test nyc ava -v && rimraf test/temp",
     "nyc:report": "nyc report --reporter=html",
     "prepublishOnly": "babel core --out-dir dist --copy-files"
   },

--- a/packages/tb-lavas-core/test/fixtures/simple/entries/test/config.js
+++ b/packages/tb-lavas-core/test/fixtures/simple/entries/test/config.js
@@ -1,0 +1,4 @@
+exports = module.exports = {
+    urlReg: /test/,
+    pages: ['index']
+}

--- a/packages/tb-lavas-core/test/unit/config-reader/development.test.js
+++ b/packages/tb-lavas-core/test/unit/config-reader/development.test.js
@@ -13,6 +13,8 @@ import {syncConfig, makeTempDir, test} from '../../utils';
 test('it should merge middlewares defined in lavas.config.js and defaults correctly', async t => {
     let core = t.context.core;
     await core.init('development', true);
+    core.builder.reloadClient();
+    core.builder.startRebuild();
     /**
      * default            all: []
      * lavas.config.js    all: ['both']

--- a/packages/tb-lavas-core/test/unit/utils/composer.test.js
+++ b/packages/tb-lavas-core/test/unit/utils/composer.test.js
@@ -22,4 +22,12 @@ test('Composer base function scope test case.', async t => {
     composer.reset({});
     t.is(composer.internalMiddlewares.length, 0);
     t.is(typeof composer.config.buildVersion, 'number');
+    let comTestBase = composer.reset({router:{base:''}});
+    let comNovar = composer.express();
+    t.is(composer.config.router.base, '');
+    try {
+       composer.add(1);
+    } catch(e) {
+        t.is(/Middleware/.test(e.message), true);
+    }
 });

--- a/packages/tb-lavas-core/test/unit/utils/server-error.test.js
+++ b/packages/tb-lavas-core/test/unit/utils/server-error.test.js
@@ -1,0 +1,70 @@
+/**
+ * @file test case for middleware-composer.js
+ * @author xtx1130@gmail.com <小菜>
+ */
+
+import test from 'ava';
+import http from 'http';
+import expressErrorFactory from '../../../core/middlewares/express-error';
+
+function requestListenerNoRedrict(req, res) {
+    expressErrorFactory({
+        errorPath:'/',
+        defaultErrorMessage: 'test',
+        showRealErrorMessage: 'test-real'
+    }).call(global, new Error('test'), req, res, function noop(){});
+}
+
+function requestListenerRedrict(req, res) {
+    expressErrorFactory({
+        errorPath:'/?error=1',
+        defaultErrorMessage: 'test',
+        showRealErrorMessage: 'test-real'
+    }).call(global, new Error('test'), req, res, function noop(){});
+}
+
+const serverNoRedrict = http.createServer(requestListenerNoRedrict);
+serverNoRedrict.listen('8999');
+
+const serverRedrict = http.createServer(requestListenerRedrict);
+serverRedrict.listen('8998');
+
+test('Test for error middleware 404.', async t => {
+    return new Promise((resolve, reject) => {
+        let httpReq = http.request({
+            host: 'localhost',
+            port: 8999,
+            path: '/'
+        }, res => {
+            t.is(res.statusCode, 404);
+            serverNoRedrict.close();
+            resolve();
+        });
+        httpReq.on('error', e => {
+            t.is(e.message, 'test');
+            serverNoRedrict.close();
+            reject();
+        });
+        httpReq.end();
+    });
+});
+
+test('Test for error middleware 302.', async t => {
+    return new Promise((resolve, reject) => {
+        let httpReq = http.request({
+            host: 'localhost',
+            port: 8998,
+            path: '/'
+        }, res => {
+            t.is(res.statusCode, 302);
+            serverRedrict.close();
+            resolve();
+        });
+        httpReq.on('error', e => {
+            t.is(e.message, 'test');
+            serverRedrict.close();
+            reject();
+        });
+        httpReq.end();
+    });
+});


### PR DESCRIPTION
- 增加测试用例
- 忽略部分error的coveralls
- 修正`express-error`中间件在抛错情况下返回200状态码的问题