### PR TITLE
lock webpack-hot-middleware

### DIFF
--- a/packages/lavas-core-vue/package.json
+++ b/packages/lavas-core-vue/package.json
@@ -84,7 +84,7 @@
     "webpack-bundle-analyzer": "^2.8.2",
     "webpack-chain": "^4.5.0",
     "webpack-dev-middleware": "^1.12.0",
-    "webpack-hot-middleware": "^2.19.0",
+    "webpack-hot-middleware": "~2.22.0",
     "webpack-node-externals": "^1.6.0",
     "workbox-webpack-plugin": "^3.4.1"
   },


### PR DESCRIPTION
webpack-hot-middleware@v.2.23.0 导致 `lavas dev` 运行出错